### PR TITLE
Add Finder alias

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -50,6 +50,7 @@ alias llx='ls -l -a'
 alias la='ls -A'
 alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
 alias docker='podman'
+alias finder='open .'
 
 # ============================
 # Editor Configuration


### PR DESCRIPTION
## Summary
- add a `finder` alias to `.zshrc`

## Testing
- `shellcheck zsh/.zshrc` *(fails: SC2148 and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68617b4eb15483289e5cfafe03c064c0